### PR TITLE
Fixed early exit bug

### DIFF
--- a/Gradient Follow/Challenge 3 - Alternate Food Behavoir.c
+++ b/Gradient Follow/Challenge 3 - Alternate Food Behavoir.c
@@ -239,7 +239,7 @@ task followFoodLeft() {
     float offset = 3.0;
     int wrongWayCount = 0;
     while (rightLumenance < WHITE) { //move until right gets on white
-    	lSpeed = BASESPEED; //will need a way to break out eventuallu
+    	lSpeed = BASESPEED; //will need a way to break out eventually
     	rSpeed = BASESPEED;
     }
     while (doOver) {
@@ -298,7 +298,7 @@ task followFoodLeft() {
      			}
        	}
    		}
-   		if (wrongWayCount >= 2) {
+   		if (wrongWayCount >= 20) {
    			doOver = false; //something has gone wrong, exit
    			break;
    		}
@@ -399,7 +399,7 @@ task followFoodRight() {
      			}
        	}
    		}
-   		if (wrongWayCount >= 2) {
+   		if (wrongWayCount >= 20) {
    			doOver = false;
    			break;
    		}


### PR DESCRIPTION
I did not test the wrongWayCount break as much as was needed. Now I have.
I assumed turn around methods were only called once, but they were being called multiple times but it worked in favor the the program. This higher count check accommodates that.
